### PR TITLE
Do not set SMB2_GLOBAL_CAP_ENCRYPTION for SMB 3.1.1. Fixes #550

### DIFF
--- a/smb2ops.c
+++ b/smb2ops.c
@@ -323,9 +323,6 @@ int init_smb3_11_server(struct ksmbd_conn *conn)
 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_SMB2_LEASES)
 		conn->vals->capabilities |= SMB2_GLOBAL_CAP_LEASING;
 
-	if (conn->cipher_type)
-		conn->vals->capabilities |= SMB2_GLOBAL_CAP_ENCRYPTION;
-
 	if (server_conf.flags & KSMBD_GLOBAL_FLAG_SMB3_MULTICHANNEL)
 		conn->vals->capabilities |= SMB2_GLOBAL_CAP_MULTI_CHANNEL;
 


### PR DESCRIPTION
According to the official Microsoft MS-SMB2 document section 3.3.5.4, this
flag should be used only for 3.0 and 3.0.2 dialects. Setting it for 3.1.1 is
a violation of the specification.

This caused Windows 10 to detect a mistake in the protocol, and disable
encryption despite being enabled in the settings.