### PR TITLE
ksmbd: fixes build on kernel 5.15.52 or higher

### DIFF
--- a/smbacl.c
+++ b/smbacl.c
@@ -281,7 +281,8 @@ static int sid_to_id(struct user_namespace *user_ns,
 		uid_t id;
 
 		id = le32_to_cpu(psid->sub_auth[psid->num_subauth - 1]);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0) || \
+    (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 52) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0))
 		uid = mapped_kuid_user(user_ns, &init_user_ns, KUIDT_INIT(id));
 #else
 		/*
@@ -304,7 +305,8 @@ static int sid_to_id(struct user_namespace *user_ns,
 		gid_t id;
 
 		id = le32_to_cpu(psid->sub_auth[psid->num_subauth - 1]);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0) || \
+    (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 52) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0))
 		gid = mapped_kgid_user(user_ns, &init_user_ns, KGIDT_INIT(id));
 #else
 		/*

--- a/smbacl.h
+++ b/smbacl.h
@@ -221,7 +221,8 @@ static inline uid_t posix_acl_uid_translate(struct user_namespace *mnt_userns,
 	kuid_t kuid;
 
 	/* If this is an idmapped mount, apply the idmapping. */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0) || \
+    (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 52) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0))
 	kuid = mapped_kuid_fs(mnt_userns, &init_user_ns, pace->e_uid);
 #else
 	kuid = kuid_into_mnt(mnt_userns, pace->e_uid);
@@ -241,7 +242,8 @@ static inline gid_t posix_acl_gid_translate(struct user_namespace *mnt_userns,
 	kgid_t kgid;
 
 	/* If this is an idmapped mount, apply the idmapping. */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0) || \
+    (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 52) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0))
 	kgid = mapped_kgid_fs(mnt_userns, &init_user_ns, pace->e_gid);
 #else
 	kgid = kgid_into_mnt(mnt_userns, pace->e_gid);


### PR DESCRIPTION
The 5.15.52 kernel downported two commits "fs: remove unused low-level
mapping helpers" and "fs: use low-level mapping helpers", which broken
the compilation[1]. This commit fixed it.

1. https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.52