### PR TITLE
ignore trailing slash in share path

### DIFF
--- a/mgmt/share_config.c
+++ b/mgmt/share_config.c
@@ -165,8 +165,14 @@ static struct ksmbd_share_config *share_config_request(struct unicode_map *um,
 
 		share->path = kstrndup(ksmbd_share_config_path(resp), path_len,
 				      GFP_KERNEL);
-		if (share->path)
+		if (share->path) {
 			share->path_sz = strlen(share->path);
+			while (share->path_sz > 1 && share->path[share->path_sz - 1] == '/')
+			{
+				share->path[share->path_sz - 1] = '\0';
+				share->path_sz--;
+			}
+		}
 		share->create_mask = resp->create_mask;
 		share->directory_mask = resp->directory_mask;
 		share->force_create_mode = resp->force_create_mode;


### PR DESCRIPTION
Trailing slashes in share paths (like: `/home/me/Share/`) caused permission issues with shares for clients on iOS and on Android TV for me, but otherwise they work fine with plain old Samba.

Might not be the best place to handle this, I'm open for suggestions! :)